### PR TITLE
Update CI to Fedora 32 and drop F30

### DIFF
--- a/.github/workflows/bandit.yaml
+++ b/.github/workflows/bandit.yaml
@@ -16,7 +16,7 @@ jobs:
             engine: docker
 
           - name: fedora
-            version: 31
+            version: 32
             python: 3
             engine: docker
 

--- a/.github/workflows/pylint.yaml
+++ b/.github/workflows/pylint.yaml
@@ -11,12 +11,12 @@ jobs:
       matrix:
         os:
           - name: fedora
-            version: 29
+            version: 31
             python: 2
             engine: docker
 
           - name: fedora
-            version: 31
+            version: 32
             python: 3
             engine: docker
 

--- a/.github/workflows/test_sh.yaml
+++ b/.github/workflows/test_sh.yaml
@@ -17,12 +17,12 @@ jobs:
             engine: docker
 
           - name: fedora
-            version: 30
+            version: 31
             python: 3
             engine: docker
 
           - name: fedora
-            version: 31
+            version: 32
             python: 3
             engine: docker
 

--- a/test.sh
+++ b/test.sh
@@ -138,7 +138,7 @@ function setup_osbs() {
 case ${ACTION} in
 "test")
   setup_osbs
-  TEST_CMD="coverage run --source=atomic_reactor -m pytest --color=yes tests"
+  TEST_CMD="coverage run --source=atomic_reactor -m pytest -ra tests"
   ;;
 "pylint")
   setup_osbs


### PR DESCRIPTION
Signed-off-by: Ben Alkov <ben.alkov@redhat.com>

* CLOUDBLD-1521

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
